### PR TITLE
invert operators with edges, by doing that the edges traversal is bec…

### DIFF
--- a/docs/rfcs/rfc-040-relay-first-api.md
+++ b/docs/rfcs/rfc-040-relay-first-api.md
@@ -182,20 +182,24 @@ For filtering edges, we can use the `fields` property and the array operators if
 
 ```graphql
 query PeopleAndMoviesActedAfter2001 {
-    peopleConnection(where: { edges: { node: { movies: { edges: { some: { fields: { year: { gt: 1999 } } } } } } } }) {
-        edges {
-            node {
-                name
-                movies {
-                    edges {
-                        node {
-                            title
-                        }
-                    }
-                }
-            }
-        }
+  peopleConnection(
+    where: {
+      edges: { node: { movies: { some: { fields: { year: { gt: 1999 } } } } } }
     }
+  ) {
+    edges {
+      node {
+        name
+        movies {
+          edges {
+            node {
+              title
+            }
+          }
+        }
+      }
+    }
+  }
 }
 ```
 
@@ -690,11 +694,11 @@ interface ActedIn {
 ### "Top Level" aggregation
 
 type MoviesAggregation {
-    node: MoviesAggregationNode!
+    nodes: MoviesAggregationNode!
 }
 
 type PeopleAggregation {
-    node: PeopleAggregationNode!
+    nodes: PeopleAggregationNode!
 }
 
 ### "Node" aggregation

--- a/docs/rfcs/rfc-040-relay-first-api.md
+++ b/docs/rfcs/rfc-040-relay-first-api.md
@@ -797,18 +797,11 @@ input MovieActorsConnectionWhere {
     AND: [MovieActorsConnectionWhere!]
     OR: [MovieActorsConnectionWhere!]
     NOT: MovieActorsConnectionWhere
-    edges: MovieActorsWhereFilters
-    aggregation: MovieActorsAggregationEdgeWhere
-}
-
-input MovieActorsWhereFilters {
-    AND: [MovieActorsWhereFilters!]
-    OR: [MovieActorsWhereFilters!]
-    NOT: MovieActorsWhereFilters
     all: MovieActorsEdgeWhere
     none: MovieActorsEdgeWhere
     single: MovieActorsEdgeWhere
     some: MovieActorsEdgeWhere
+    aggregation: MovieActorsAggregationEdgeWhere
 }
 
 input MovieDirectorConnectionWhere {
@@ -822,18 +815,11 @@ input PersonMoviesConnectionWhere {
     AND: [PersonMoviesConnectionWhere!]
     OR: [PersonMoviesConnectionWhere!]
     NOT: PersonMoviesConnectionWhere
-    edges: PersonMoviesWhereFilters
-    aggregation: PersonMoviesAggregationEdgeWhere
-}
-
-input PersonMoviesWhereFilters {
-    AND: [PersonMoviesWhereFilters!]
-    OR: [PersonMoviesWhereFilters!]
-    NOT: PersonMoviesWhereFilters
     all: PersonMoviesEdgeWhere
     none: PersonMoviesEdgeWhere
     single: PersonMoviesEdgeWhere
     some: PersonMoviesEdgeWhere
+    aggregation: PersonMoviesAggregationEdgeWhere
 }
 
 input PersonDirectedConnectionWhere {
@@ -1185,7 +1171,7 @@ The following are some example queries on the previous schema:
 ```graphql
 query MoviesWithAllActorsNamedKeanuReeves {
     moviesConnection(
-        where: { edges: { node: { actors: { edges: { all: { node: { name: { equals: "Keanu Reeves" } } } } } } } }
+        where: { edges: { node: { actors: { all: { node: { name: { equals: "Keanu Reeves" } } }  } } } }
     ) {
         edges {
             node {
@@ -1249,7 +1235,7 @@ query MoviesWithMoreThan10ActorNodes {
 }
 
 query MoviesWithMoreThan10ActorEdges {
-    moviesConnection(where: { edges: { node: { actors: { aggregation: { count: { gt: 10 } } } } } }) {
+    moviesConnection(where: { edges: { node: { actors: { aggregation: { nodes: { count: { gt: 10 } } } } } } }) {
         edges {
             node {
                 actors {
@@ -1259,7 +1245,7 @@ query MoviesWithMoreThan10ActorEdges {
                         }
                     }
                     aggregation {
-                        node {
+                        nodes {
                             count
                         }
                     }
@@ -1288,7 +1274,7 @@ query GetMoviesPaginatedIn10 {
 }
 
 query PaginateActorsInMovie {
-    moviesConnection(where: { edges: { node: { title: { equal: "The Matrix" } } } }) {
+    moviesConnection(where: { edges: { node: { title: { equals: "The Matrix" } } } }) {
         edges {
             node {
                 actors(sort: [{ edges: { fields: { year: DESC } } }, { edges: { node: { name: ASC } } }], first: 20) {


### PR DESCRIPTION
# Invert order between edges and filters

This PR proposes to invert the input order between `edges` and the operators `all`/`none`/`some`/`single`. As the scope of the `edges` field was to wrap these operators now is becoming completely redundant.
This means that the verbosity is reduced but there is no anymore a match on the `edges` field between the `selectionSet` and the where input.

## Complexity

Complexity: Low

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [x] Documentation has been updated
- [x] TCK tests have been updated
- [x] Integration tests have been updated
- [x] Example applications have been updated
- [x] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
